### PR TITLE
change dead instance to invidious.snopyta.org

### DIFF
--- a/frontend/src/models/archive.ts
+++ b/frontend/src/models/archive.ts
@@ -37,5 +37,5 @@ function shortenArchiveURL(archiveURL: string): string {
  * @param archiveURL 
  */
 function lengthenArchiveURL(archiveURL: string): string {
-    return "https://invidious.xyz/embed/" + archiveURL;
+    return "https://invidious.snopyta.org/embed/" + archiveURL;
 }


### PR DESCRIPTION
apparently google killed the other instance a little while ago, so we might need to move to this other one. If this instance dies, we'll just have to move back to youtube-nocookie and send all our data to google again.